### PR TITLE
chore: update ucla-library-website-components to v1.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^3.9.1",
-                "ucla-library-website-components": "^v1.27.3",
+                "ucla-library-website-components": "^v1.29.0",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14593,9 +14593,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.27.3",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.27.3.tgz",
-            "integrity": "sha512-NCnALccHw/+JVssu+KOOTStBdFiSvvh1lhrsZA2weVDEEKIRml6uQb4Elf5uaivqP9EPKIWdPLe/rMNQV3U31g==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.29.0.tgz",
+            "integrity": "sha512-mTKn77wp3VYCveC8y7Ir5Xzr1vMsWM89pbWpu6bD8OWRAd7suOUbGcoXdPUPH4qpM0u1I/guRXTVnQZyY+K11A==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28012,9 +28012,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.27.3",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.27.3.tgz",
-            "integrity": "sha512-NCnALccHw/+JVssu+KOOTStBdFiSvvh1lhrsZA2weVDEEKIRml6uQb4Elf5uaivqP9EPKIWdPLe/rMNQV3U31g==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.29.0.tgz",
+            "integrity": "sha512-mTKn77wp3VYCveC8y7Ir5Xzr1vMsWM89pbWpu6bD8OWRAd7suOUbGcoXdPUPH4qpM0u1I/guRXTVnQZyY+K11A==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
         "ucla-library-design-tokens": "^3.9.1",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12",
-        "ucla-library-website-components":"^v1.27.3"
+        "ucla-library-website-components":"^v1.29.0"
     }
 }


### PR DESCRIPTION
update ucla-library-website-components to v1.29.0

- [x] I added the github label for the release drafter GH action