### PR TITLE
fix: update flexible associated topics paths

### DIFF
--- a/gql/fragments/BlockAssociatedTopicCardsFragment.gql
+++ b/gql/fragments/BlockAssociatedTopicCardsFragment.gql
@@ -9,7 +9,8 @@ fragment BlockAssociatedTopicCardsFragment on ElementInterface {
             topics {
                 title
                 typeHandle
-                to: uri
+                externalResourceUrl
+                uri
                 text: summary
                 uri
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^4.6.2",
-                "ucla-library-website-components": "^1.51.8",
+                "ucla-library-website-components": "^1.51.9",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14925,9 +14925,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.51.8",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.51.8.tgz",
-            "integrity": "sha512-kP1jyz7qaDeLMpELx6nSnbJNtVjUOuqUu/agHVOTxDSv8x/yid4qZ5IdcFCt5EDtjfLWyb8gVB6ZRxWSRpxPlg==",
+            "version": "1.51.9",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.51.9.tgz",
+            "integrity": "sha512-QBJWTYh+2O7XfmZPuC5g69GlSNgxHS8Cy/j59em6jj1VX+oGZg50KFFuiYnIjMfVudqZIcCrusHwZ0BY2rJEig==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28625,9 +28625,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.51.8",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.51.8.tgz",
-            "integrity": "sha512-kP1jyz7qaDeLMpELx6nSnbJNtVjUOuqUu/agHVOTxDSv8x/yid4qZ5IdcFCt5EDtjfLWyb8gVB6ZRxWSRpxPlg==",
+            "version": "1.51.9",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.51.9.tgz",
+            "integrity": "sha512-QBJWTYh+2O7XfmZPuC5g69GlSNgxHS8Cy/j59em6jj1VX+oGZg50KFFuiYnIjMfVudqZIcCrusHwZ0BY2rJEig==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^4.6.2",
-        "ucla-library-website-components": "^1.51.8",
+        "ucla-library-website-components": "^1.51.9",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }


### PR DESCRIPTION
fix: update flexible associated topics paths
Associated topic cards on https://deploy-preview-45--test-meap.netlify.app/about/news/learn-elastic-search both go to expected links