### PR TITLE
fix: update help topic page

### DIFF
--- a/gql/fragments/BlockSimpleCardsFragment.gql
+++ b/gql/fragments/BlockSimpleCardsFragment.gql
@@ -6,8 +6,7 @@ fragment BlockSimpleCardsFragment on ElementInterface {
     cards: meapflexiblePageBlocks_simpleCards {
         ... on meapflexiblePageBlocks_simpleCards_internalResource_BlockType {
             id
-            title: titleGeneral
-            summary
+            typeHandle
             contentLink {
                 id
                 uri
@@ -18,6 +17,7 @@ fragment BlockSimpleCardsFragment on ElementInterface {
         }
         ... on meapflexiblePageBlocks_simpleCards_externalResource_BlockType {
             id
+            typeHandle
             title: titleGeneral
             summary
             externalLink

--- a/gql/queries/HelpTopicDetail.gql
+++ b/gql/queries/HelpTopicDetail.gql
@@ -11,9 +11,10 @@ query HelpTopicDetail($slug: [String!]) {
             sectionTitle
             sectionSummary
             associatedEntries {
-                to: uri
+                uri
                 title
                 text: summary
+                externalResourceUrl
             }
         }
         ...MEAPDefaultFpb

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^4.6.2",
-                "ucla-library-website-components": "^1.52.7",
+                "ucla-library-website-components": "^1.52.8",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14931,9 +14931,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.52.7",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.7.tgz",
-            "integrity": "sha512-I4nQWlMzI+gSFJc0lva7vpvCN9NO0Ebos/wneQM1Rs0JkFWLzytvFKSUErEYNdR7uE4EVmHi/24/m6SMcP8CMQ==",
+            "version": "1.52.8",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.8.tgz",
+            "integrity": "sha512-N3nZRXcMTgrpfv0xCxLmTjWYpyzUcdpECXHAo8dJeq4kaRr/tu4hWng/jtpdyL3GpzX+BNoEjX6Mq85CFyleGA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28636,9 +28636,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.52.7",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.7.tgz",
-            "integrity": "sha512-I4nQWlMzI+gSFJc0lva7vpvCN9NO0Ebos/wneQM1Rs0JkFWLzytvFKSUErEYNdR7uE4EVmHi/24/m6SMcP8CMQ==",
+            "version": "1.52.8",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.8.tgz",
+            "integrity": "sha512-N3nZRXcMTgrpfv0xCxLmTjWYpyzUcdpECXHAo8dJeq4kaRr/tu4hWng/jtpdyL3GpzX+BNoEjX6Mq85CFyleGA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^4.6.2",
-        "ucla-library-website-components": "^1.52.7",
+        "ucla-library-website-components": "^1.52.8",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/applicants/_slug.vue
+++ b/pages/applicants/_slug.vue
@@ -11,7 +11,6 @@
             :title="page.title"
             :text="page.summary"
         />
-
         <section-wrapper>
             <rich-text
                 v-if="page.richText"
@@ -21,14 +20,17 @@
         </section-wrapper>
 
         <section-wrapper
-            v-if="page.richText && page.helpTopicBlocks && page.helpTopicBlocks.length"
+            v-if="
+                page.richText &&
+                    page.helpTopicBlocks &&
+                    page.helpTopicBlocks.length
+            "
             theme="divider"
         >
             <divider-way-finder color="about" />
         </section-wrapper>
-
         <section-wrapper
-            v-for="(block, index) in page.helpTopicBlocks"
+            v-for="(block, index) in parsedHelpTopicBlocks"
             v-if="page.helpTopicBlocks && page.helpTopicBlocks.length"
             :key="`HelpTopicBlocksKey${index}`"
             class="help-topic-section"
@@ -37,9 +39,18 @@
                 class="help-topic-block"
                 :section-title="block.sectionTitle"
                 :section-summary="block.sectionSummary"
-                :items="block.associatedEntries"
+                :items="block.parsedAssociatedEntries"
             />
 
+        <section-wrapper
+            v-if="
+                (page.richText ||
+                    (page.helpTopicBlocks && page.helpTopicBlocks.length)) &&
+                    page.blocks &&
+                    page.blocks.length
+            "
+            theme="divider"
+        >
             <divider-way-finder color="about" />
         </section-wrapper>
 
@@ -74,9 +85,36 @@ export default {
             title: title,
         }
     },
+    computed: {
+        parsedHelpTopicBlocks() {
+            return this.page.helpTopicBlocks.map((obj) => {
+                return {
+                    ...obj,
+                    parsedAssociatedEntries: obj.associatedEntries.map(
+                        (entry) => {
+                            return {
+                                ...entry,
+                                to: entry.externalResourceUrl
+                                    ? entry.externalResourceUrl
+                                    : `/${entry.uri}`,
+                            }
+                        }
+                    ),
+                }
+            })
+            // return this.page.helpTopicBlocks.map((obj) =>
+            //     obj.associatedEntries.map((entry) =>
+            //         entry.externalResourceUrl
+            //             ? entry.externalResourceUrl
+            //             : `/${entry.uri}`
+            //     )
+            // )
+        },
+    },
 }
 </script>
 
+<<<<<<< HEAD
 <style lang="scss" scoped>
 .page-help-topic {
     .banner-text,
@@ -91,3 +129,6 @@ export default {
     }
 }
 </style>
+=======
+<style lang="scss" scoped></style>
+>>>>>>> 6eb8028 (fix: update help topic page)

--- a/pages/applicants/_slug.vue
+++ b/pages/applicants/_slug.vue
@@ -41,6 +41,7 @@
                 :section-summary="block.sectionSummary"
                 :items="block.parsedAssociatedEntries"
             />
+        </section-wrapper>
 
         <section-wrapper
             v-if="
@@ -107,12 +108,11 @@ export default {
 }
 </script>
 
-
 <style lang="scss" scoped>
 .page-help-topic {
     .banner-text,
     .banner-header {
-      --color-theme: var(--color-about-purple-03);
+        --color-theme: var(--color-about-purple-03);
     }
 
     .help-topic-section:last-child {

--- a/pages/applicants/_slug.vue
+++ b/pages/applicants/_slug.vue
@@ -107,7 +107,7 @@ export default {
 }
 </script>
 
-<<<<<<< HEAD
+
 <style lang="scss" scoped>
 .page-help-topic {
     .banner-text,
@@ -122,6 +122,3 @@ export default {
     }
 }
 </style>
-=======
-<style lang="scss" scoped></style>
->>>>>>> 6eb8028 (fix: update help topic page)

--- a/pages/applicants/_slug.vue
+++ b/pages/applicants/_slug.vue
@@ -41,17 +41,6 @@
                 :section-summary="block.sectionSummary"
                 :items="block.parsedAssociatedEntries"
             />
-        </section-wrapper>
-
-        <section-wrapper
-            v-if="
-                (page.richText ||
-                    (page.helpTopicBlocks && page.helpTopicBlocks.length)) &&
-                    page.blocks &&
-                    page.blocks.length
-            "
-            theme="divider"
-        >
             <divider-way-finder color="about" />
         </section-wrapper>
 

--- a/pages/applicants/_slug.vue
+++ b/pages/applicants/_slug.vue
@@ -102,13 +102,6 @@ export default {
                     ),
                 }
             })
-            // return this.page.helpTopicBlocks.map((obj) =>
-            //     obj.associatedEntries.map((entry) =>
-            //         entry.externalResourceUrl
-            //             ? entry.externalResourceUrl
-            //             : `/${entry.uri}`
-            //     )
-            // )
         },
     },
 }


### PR DESCRIPTION
[APPS-1858](https://jira.library.ucla.edu/browse/APPS-1858)

Links for simple cards in https://meapprod.library.ucla.edu/applicants/applicant-resources/ do not point to the correct path. For example, "Project Grants" goes to https://meapprod.library.ucla.edu/applicants/applicant-resources/about/project-grants instead of /about/project-grants.

Some general content pages still break. Simple Card pr will fix that.
