### PR TITLE
fix: open links in correct tabs

### DIFF
--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -35,6 +35,8 @@ describe("Website Homepage", () => {
             "News"
         )
 
+        cy.contains("a.smart-link", "Browse Collections").should("have.attr", "target", "_blank")
+
         // MastheadPrimary
         // cy.get(".masthead-primary").find(".logo").should("be.visible")
         // cy.get(".masthead-primary")

--- a/cypress/integration/projectdetailpage.spec.js
+++ b/cypress/integration/projectdetailpage.spec.js
@@ -5,6 +5,12 @@ describe("Project Detail page", () => {
         // UCLA Library brand
         cy.get(".logo-ucla").should("be.visible")
         cy.get("h1.title").should("contain", "Kids Play Project")
+
+        // "Target" attribute for links
+        cy.contains("a.button-link", "Brahma Kumaris").should("have.attr", "target", "_blank")
+        cy.contains("a.smart-link", "Metadata Planning Worksheet").should("have.attr", "target", "_blank")
+        cy.contains("a.smart-link", "Kids Play").should("not.have.attr", "target", "_blank")
+
         cy.percySnapshot({ widths: [768, 992, 1200] })
     })
 })

--- a/cypress/integration/projectlistingpage.spec.js
+++ b/cypress/integration/projectlistingpage.spec.js
@@ -5,6 +5,10 @@ describe("Project Listing page", () => {
         // UCLA Library brand
         cy.get(".logo-ucla").should("be.visible")
         cy.get("h1.title").should("contain", "Funded Projects")
+
+        // projects open in same tab
+        cy.get("li.block-highlight a.smart-link:first-child").should("not.have.attr", "target", "_blank")
+
         cy.percySnapshot({ widths: [768, 992, 1200] })
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^4.6.2",
-                "ucla-library-website-components": "^1.52.16",
+                "ucla-library-website-components": "^1.53.0",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14997,9 +14997,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.52.16",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.16.tgz",
-            "integrity": "sha512-xtGcAMhzdVfAOZxXmbhZAFOEeiowH9lvKrkGF/+MeJsPQWDFIJN4/Houb3u+I8s8Xr67l31Kbrti99jJkoY5DA==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.0.tgz",
+            "integrity": "sha512-BGKx3JV0w6IJaG0JEw97dAzHj43Srimu3OHgR1gN0t8a555p8vZ33ZhoDhBBF5XfzqkXGNWE5SP1NWFIAiz3aA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28756,9 +28756,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.52.16",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.52.16.tgz",
-            "integrity": "sha512-xtGcAMhzdVfAOZxXmbhZAFOEeiowH9lvKrkGF/+MeJsPQWDFIJN4/Houb3u+I8s8Xr67l31Kbrti99jJkoY5DA==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.0.tgz",
+            "integrity": "sha512-BGKx3JV0w6IJaG0JEw97dAzHj43Srimu3OHgR1gN0t8a555p8vZ33ZhoDhBBF5XfzqkXGNWE5SP1NWFIAiz3aA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^4.6.2",
-        "ucla-library-website-components": "^1.52.16",
+        "ucla-library-website-components": "^1.53.0",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }


### PR DESCRIPTION
upgrades ucla-library-website-component to include a fix that ensures links correctly open in the same vs new tabs