### PR TITLE
fix: add divider-way-finder to _parent/index page and update divider color

### DIFF
--- a/pages/_parent/index.vue
+++ b/pages/_parent/index.vue
@@ -26,6 +26,13 @@
             />
         </section-wrapper>
 
+        <section-wrapper theme="divider">
+            <divider-way-finder
+                class="divider-way-finder"
+                color="visit"
+            />
+        </section-wrapper>
+
         <flexible-blocks
             class="flexible-content"
             :blocks="page.blocks"
@@ -46,7 +53,6 @@ export default {
         const data = await $graphql.default.request(GENERAL_CONTENT_DETAIL, {
             slug: params.parent,
         })
-        console.log("parent SLUG:" + params.parent)
         return {
             page: _get(data, "entry", {}),
         }
@@ -69,6 +75,10 @@ export default {
 
     .section-banner {
         margin-top: 0;
+    }
+
+    ::v-deep .divider-way-finder {
+        --color-border: var(--color-visit-fushia-03);
     }
 }
 </style>


### PR DESCRIPTION
fix: add divider-way-finder to _parent/index page and update divider color

Add divider-way-finder after banner-text
Update way-finder-color theme to visit-fuschia

![Screen Shot 2022-09-01 at 1 48 44 PM](https://user-images.githubusercontent.com/34147754/188009793-af0e113c-f275-4164-bacd-3a6ef211a817.png)

