### PR TITLE
fix: Add  upload assets to GQL and pass it to BannerHeader and BannerText

### DIFF
--- a/cypress/integration/projectdetailpage.spec.js
+++ b/cypress/integration/projectdetailpage.spec.js
@@ -13,4 +13,16 @@ describe("Project Detail page", () => {
 
         cy.percySnapshot({ widths: [768, 992, 1200] })
     })
+    it("Call to action Upload assests works on Project Page", () => {
+        cy.visit("/projects/vintage-whoopie-cushions")
+
+        // UCLA Library brand
+        cy.get(".logo-ucla").should("be.visible")
+        cy.get("h1.title").should("contain", "Famous Fountains of Italy")
+
+        // "Target" attribute for links
+        cy.contains("a.button-link", "Explore Inventory").should("have.attr", "target", "_blank")
+
+        cy.percySnapshot({ widths: [768, 992, 1200] })
+    })
 })

--- a/gql/queries/ProjectDetail.gql
+++ b/gql/queries/ProjectDetail.gql
@@ -23,8 +23,10 @@ query ProjectDetail($slug: [String!]) {
       }
       ... on meapProjectCallToAction_uploadAsset_BlockType {
         id
+        buttonText
         uploadAsset {
           id
+          url
         }
       }
     }

--- a/pages/projects/_slug.vue
+++ b/pages/projects/_slug.vue
@@ -155,7 +155,22 @@ export default {
             return _get(this.page, "meapProjectCallToAction[0].buttonText", "")
         },
         parsedButtonTo() {
-            return _get(this.page, "meapProjectCallToAction[0].externalUrl", "")
+            console.log(
+                "call to action data :" +
+                    JSON.stringify(this.page.meapProjectCallToAction[0])
+            )
+            let buttonTo = _get(
+                this.page,
+                "meapProjectCallToAction[0].externalUrl",
+                ""
+            )
+            return buttonTo
+                ? buttonTo
+                : _get(
+                    this.page,
+                    "meapProjectCallToAction[0].uploadAsset[0].url",
+                    ""
+                )
         },
     },
 }


### PR DESCRIPTION
[APPS-1878](https://jira.library.ucla.edu/browse/APPS-1878)
https://deploy-preview-78--test-meap.netlify.app/projects/vintage-whoopie-cushions

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/4259468/188205222-e7060d71-6b32-45b5-93a1-c207dae18d71.png">


**Page/Pages Created/updated:** /projects/_slug.vue from 

**Notes:**

Future work add support to send is-download prop to button link in BannerHeader and BannerText

**Time Report:**

This took me 45 mins to build this.

**Checklist:**

-   [x] I double checked it has a GitHub Label for semantic versioning.
-   [x] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [x] I included a working spec file
-   [x] I added notes above about how long it took to build this component
-   [ ]  UX has reviewed this PR
-   [ ] I assigned this PR to someone to review
