### PR TITLE
fix: update component library with BlockStaffArticleList default image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^4.6.2",
-                "ucla-library-website-components": "^1.53.1",
+                "ucla-library-website-components": "^1.53.2",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -14997,9 +14997,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "1.53.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.1.tgz",
-            "integrity": "sha512-HfxL7B8UOOVeSJGJ7ts8CI5zWk9ze/6TepISPs6qr14J4m/YpyrArQ16FPA7QaQK6J2X813IBhmVK4kH6ifQ/g==",
+            "version": "1.53.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.2.tgz",
+            "integrity": "sha512-Fa1r3WRsLG/SpmWr8iCQjXBJdRFyS4hOtyaHrLVw2hT3vZ5UJ2VOz4CZVP0MJ5tDppvZ6wC8+dodEJTNttAjnA==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -28756,9 +28756,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "1.53.1",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.1.tgz",
-            "integrity": "sha512-HfxL7B8UOOVeSJGJ7ts8CI5zWk9ze/6TepISPs6qr14J4m/YpyrArQ16FPA7QaQK6J2X813IBhmVK4kH6ifQ/g==",
+            "version": "1.53.2",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-1.53.2.tgz",
+            "integrity": "sha512-Fa1r3WRsLG/SpmWr8iCQjXBJdRFyS4hOtyaHrLVw2hT3vZ5UJ2VOz4CZVP0MJ5tDppvZ6wC8+dodEJTNttAjnA==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^4.6.2",
-        "ucla-library-website-components": "^1.53.1",
+        "ucla-library-website-components": "^1.53.2",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }


### PR DESCRIPTION
fix: update component library with BlockStaffArticleList default image

<img width="1043" alt="Screen Shot 2022-09-06 at 5 47 53 PM" src="https://user-images.githubusercontent.com/34147754/188929510-860d6e2c-2664-406d-bec2-12ddee2a0e4b.png">
