### PR TITLE
fix: fallback to populate menus on page load

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 .nuxt/
 node_modules/
 storybook-static/
+dist/

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -76,6 +76,14 @@ export default {
             ]
         },
     },
+    mounted() {
+        if (!this.$store.state.navsReady) {
+            console.log("nav menus aren't populated - fixing that")
+            this.$store.dispatch("populateNavMenus")
+        } else {
+            console.log("nav menus ready! nothing to do :)")
+        }
+    }
 }
 </script>
 

--- a/store/index.js
+++ b/store/index.js
@@ -17,6 +17,7 @@ export const state = () => ({
     footerSponsor: {},
     footerPrimary: {},
     footerSock: {},
+    navsReady: false,
 })
 
 export const mutations = {
@@ -42,11 +43,18 @@ export const mutations = {
     SET_FOOTER_SOCK(state, data) {
         state.footerSock = data
     },
+    SET_NAV_MENUS_READY(state, navsReady) {
+        state.navsReady = navsReady
+    }
 }
 
 // Define actions
 export const actions = {
-    async nuxtServerInit({ commit }) {
+    async nuxtServerInit({ dispatch }) {
+        dispatch('populateNavMenus')
+    },
+      
+    async populateNavMenus({ commit }) {
         try {
             // console.log("Get Global data from Craft")
             
@@ -93,6 +101,8 @@ export const actions = {
                 FOOTER_SOCK_ITEMS
             )
             commit("SET_FOOTER_SOCK", footerSockData)
+
+            commit("SET_NAV_MENUS_READY", true)
         } catch (e) {
             throw new Error("Craft API error, trying to set gobals. " + e)
         }


### PR DESCRIPTION
Menu data is supposed to be retrieved from craft during site build and inserted into the static pages, which will initialize the vuex store. However, if nuxt doesn't find a page and build it into the static site, it can load as a SPA without populating the menus. This PR ensures that menus get populated in that case. (We also need to figure out why pages aren't getting populated).