### PR TITLE
fix: use desktop nav header in static site

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 .nuxt/
 node_modules/
 storybook-static/
+dist/

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -57,7 +57,7 @@ export default {
             return this.$store.state.header.secondary
         },
         isMobile() {
-            return this.$store.state.winWidth <= 1024 ? true : false
+            return (process.client) && (this.$store.state.winWidth <= 1024)
         },
         whichHeader() {
             return this.isMobile ? "header-main-responsive" : "header-main"


### PR DESCRIPTION
fixes a bug where menu links were not included in the static render, and thus not crawled, leaving some pages undiscovered

also adds `dist/` to `.eslintignore` to prevent the linter from reviewing the static build