### PR TITLE
fix: update color of external resources on listing page

### DIFF
--- a/pages/applicants/resources/index.vue
+++ b/pages/applicants/resources/index.vue
@@ -121,6 +121,11 @@ export default {
         margin: var(--space-3xl) auto;
     }
 
+    // All cards on this page should be about purple even if they are external
+    ::v-deep .block-card-with-illustration.color-default {
+        --color-theme: var(--color-about-purple-01);
+    }
+
     @media #{$medium} {
         .content,
         .section-title {


### PR DESCRIPTION
Update External Resource to use color-about on Listing page

![Screen Shot 2022-09-08 at 3 52 18 PM](https://user-images.githubusercontent.com/34147754/189239597-f11add96-2b40-496e-a79a-c985dda1dae7.png)
