### PR TITLE
fix: updates styling to override section-wrapper margin-top

### DIFF
--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -16,7 +16,7 @@
             :byline="page.byline"
         />
 
-        <section-wrapper class="section-banner">
+        <section-wrapper class="section-banner" id="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length == 1"
                 :image="page.heroImage[0].image[0]"
@@ -87,7 +87,8 @@ export default {
         --color-theme: var(--color-visit-fushia-03);
     }
 
-    .section-banner {
+    .section-banner,
+    #section-banner {
         margin-top: 0;
     }
 }

--- a/pages/applicants/resources/_slug.vue
+++ b/pages/applicants/resources/_slug.vue
@@ -19,7 +19,7 @@
             :to="parsedButtonTo"
         />
 
-        <section-wrapper class="section-banner">
+        <section-wrapper class="section-banner" id="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length >= 1"
                 :image="page.heroImage[0].image[0]"
@@ -116,7 +116,8 @@ export default {
         --color-theme: var(--color-about-purple-03);
     }
 
-    .section-banner {
+    .section-banner,
+    #section-banner {
         margin-top: 0;
     }
 }


### PR DESCRIPTION
updates section-banner styling on Resource and News slug pages with higher specificity to override the section-wrapper margin-top

**Notes:**

margin-top from section-wrapper is not currently an issue on Project slug (not sure why it's working here and not on the other pages), so the same styling has not been applied


**Checklist:**

-   [ ] I double checked it has a GitHub Label for semantic versioning.
-   [ ] I double checked it looks like the designs
-   [ ] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ]  UX has reviewed this PR
-   [ ] I assigned this PR to someone to review
