### PR TITLE
fix: adds section-wrapper to Resource associated topics

### DIFF
--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -16,7 +16,7 @@
             :byline="page.byline"
         />
 
-        <section-wrapper class="section-banner" id="section-banner">
+        <section-wrapper class="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length == 1"
                 :image="page.heroImage[0].image[0]"
@@ -87,8 +87,7 @@ export default {
         --color-theme: var(--color-visit-fushia-03);
     }
 
-    .section-banner,
-    #section-banner {
+    .section-banner{
         margin-top: 0;
     }
 }

--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -16,7 +16,7 @@
             :byline="page.byline"
         />
 
-        <section-wrapper class="section-banner">
+        <section-wrapper class="section-banner" id="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length == 1"
                 :image="page.heroImage[0].image[0]"
@@ -87,7 +87,8 @@ export default {
         --color-theme: var(--color-visit-fushia-03);
     }
 
-    .section-banner {
+    .section-banner,
+    #section-banner {
         margin-top: 0;
     }
 }

--- a/pages/applicants/resources/_slug.vue
+++ b/pages/applicants/resources/_slug.vue
@@ -47,13 +47,16 @@
             <divider-way-finder color="about" />
         </section-wrapper>
 
-        <section-cards-with-illustrations
+        <section-wrapper
             v-if="parsedAssociatedTopics && parsedAssociatedTopics.length"
-            :items="parsedAssociatedTopics"
-            title="Associated Topics"
-            button-text="All Resources"
-            to="/applicants/resources"
-        />
+            >
+            <section-cards-with-illustrations
+                :items="parsedAssociatedTopics"
+                title="Associated Topics"
+                button-text="All Resources"
+                to="/applicants/resources"
+            />
+        </section-wrapper>
 
         <section-wrapper>
             <block-call-to-action :is-meap-global="true" />

--- a/pages/applicants/resources/_slug.vue
+++ b/pages/applicants/resources/_slug.vue
@@ -19,7 +19,7 @@
             :to="parsedButtonTo"
         />
 
-        <section-wrapper class="section-banner" id="section-banner">
+        <section-wrapper class="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length >= 1"
                 :image="page.heroImage[0].image[0]"
@@ -119,8 +119,7 @@ export default {
         --color-theme: var(--color-about-purple-03);
     }
 
-    .section-banner,
-    #section-banner {
+    .section-banner {
         margin-top: 0;
     }
 }

--- a/pages/applicants/resources/_slug.vue
+++ b/pages/applicants/resources/_slug.vue
@@ -19,7 +19,7 @@
             :to="parsedButtonTo"
         />
 
-        <section-wrapper class="section-banner">
+        <section-wrapper class="section-banner" id="section-banner">
             <banner-header
                 v-if="page.heroImage && page.heroImage.length >= 1"
                 :image="page.heroImage[0].image[0]"
@@ -116,7 +116,8 @@ export default {
         --color-theme: var(--color-about-purple-03);
     }
 
-    .section-banner {
+    .section-banner,
+    #section-banner {
         margin-top: 0;
     }
 }


### PR DESCRIPTION
adds section-wrapper to Associated Topics on Resource detail page to fix tablet and mobile margins

**Notes:**

**Checklist:**

-   [x] I double checked it has a GitHub Label for semantic versioning.
-   [x] I double checked it looks like the designs
-   [x] I completed any required mobile breakpoint styling
-   [ ] I completed any required hover state styling
-   [ ] I included a working spec file
-   [ ] I added notes above about how long it took to build this component
-   [ ]  UX has reviewed this PR
-   [x] I assigned this PR to someone to review
