### PR TITLE
fix: APPS-2434 Update component library to be able to select Meap filters when hanging over block-highlight component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "sass": "^1.45.2",
                 "sass-loader": "^10.1.1",
                 "ucla-library-design-tokens": "^5.5.0",
-                "ucla-library-website-components": "^2.38.6",
+                "ucla-library-website-components": "^2.41.0",
                 "vue-svg-loader": "^0.16.0",
                 "vue-template-compiler": "^2.6.12"
             },
@@ -15140,9 +15140,9 @@
             "dev": true
         },
         "node_modules/ucla-library-website-components": {
-            "version": "2.38.6",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.38.6.tgz",
-            "integrity": "sha512-JoCkWwQz1c1Rld9ST1Tz+3ESXrtyXc1y7oX/hRFzrs3N4VTcvpHEHk5J6ZDu6J761JzmzVHOS8TVYfXq2rY2nQ==",
+            "version": "2.41.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.0.tgz",
+            "integrity": "sha512-qrVwe3FLMPzIXzsBQ5vvnBL9LF7bPnKHlK5ufWuhP3nr0l76BVlAitVhuTj18CGq0ZyVNpcBo0+NVKK0HKvUxw==",
             "dev": true,
             "dependencies": {
                 "date-fns": "^2.28.0",
@@ -29032,9 +29032,9 @@
             "dev": true
         },
         "ucla-library-website-components": {
-            "version": "2.38.6",
-            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.38.6.tgz",
-            "integrity": "sha512-JoCkWwQz1c1Rld9ST1Tz+3ESXrtyXc1y7oX/hRFzrs3N4VTcvpHEHk5J6ZDu6J761JzmzVHOS8TVYfXq2rY2nQ==",
+            "version": "2.41.0",
+            "resolved": "https://registry.npmjs.org/ucla-library-website-components/-/ucla-library-website-components-2.41.0.tgz",
+            "integrity": "sha512-qrVwe3FLMPzIXzsBQ5vvnBL9LF7bPnKHlK5ufWuhP3nr0l76BVlAitVhuTj18CGq0ZyVNpcBo0+NVKK0HKvUxw==",
             "dev": true,
             "requires": {
                 "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "sass": "^1.45.2",
         "sass-loader": "^10.1.1",
         "ucla-library-design-tokens": "^5.5.0",
-        "ucla-library-website-components": "^2.38.6",
+        "ucla-library-website-components": "^2.41.0",
         "vue-svg-loader": "^0.16.0",
         "vue-template-compiler": "^2.6.12"
     }

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -1,8 +1,5 @@
 <template lang="html">
-    <main
-        id="main"
-        class="page page-project-list"
-    >
+    <main id="main" class="page page-project-list">
         <masthead-secondary
             :title="summaryData.projectListTitle"
             :text="summaryData.projectListSummary"
@@ -16,35 +13,34 @@
             placeholder="Search Projects"
             @search-ready="getSearchData"
         />
+
         <section-wrapper theme="divider">
             <divider-way-finder class="search-margin" />
         </section-wrapper>
+
         <section-wrapper
             v-show="
                 page &&
-                    projectList.length &&
-                    hits.length == 0 &&
-                    !noResultsFound
+                projectList.length &&
+                hits.length == 0 &&
+                !noResultsFound
             "
             section-title="All Projects"
         >
             <section-teaser-card :items="projectList" />
         </section-wrapper>
+
         <section-wrapper
             v-show="hits && hits.length > 0"
             class="section-no-top-margin"
         >
-            <h2
-                v-if="$route.query.q"
-                class="about-results"
-            >
+            <h2 v-if="$route.query.q" class="about-results">
                 Displaying {{ hits.length }} results for
-                <strong><em>“{{ $route.query.q }}</em></strong>”
+                <strong
+                    ><em>“{{ $route.query.q }}</em></strong
+                >”
             </h2>
-            <h2
-                v-else
-                class="about-results"
-            >
+            <h2 v-else class="about-results">
                 Displaying {{ hits.length }} results
             </h2>
 
@@ -52,16 +48,13 @@
         </section-wrapper>
 
         <!-- NO RESULTS -->
-        <section-wrapper
-            v-show="noResultsFound"
-            class="section-no-top-margin"
-        >
+        <section-wrapper v-show="noResultsFound" class="section-no-top-margin">
             <div class="error-text">
                 <rich-text>
                     <h2>Search for “{{ $route.query.q }}” not found.</h2>
                     <p>
                         We can’t find the term you are looking for on this page.
-                        <br>
+                        <br />
                         <!-- Try searching the whole site from
                         <a href="https://library.ucla.edu">UCLA Library Home</a>, or try one of the these regularly visited links:
                     </p>
@@ -302,4 +295,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.generic-search {
+    z-index: 30;
+}
+</style>

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -299,4 +299,12 @@ export default {
 .generic-search {
     z-index: 30;
 }
+
+::v-deep .section-teaser-card {
+    z-index: 0;
+}
+
+::v-deep .block-highlight .meta {
+    z-index: 0;
+}
 </style>


### PR DESCRIPTION
Connect to [APPS-2434]([APPS-2434](https://uclalibrary.atlassian.net/jira/software/c/projects/APPS/boards/12?modal=detail&selectedIssue=APPS-2434)

Update component library to be able to select Meap filters when hanging over block-highlight component

[APPS-2434]: https://uclalibrary.atlassian.net/browse/APPS-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2434]: https://uclalibrary.atlassian.net/browse/APPS-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ