### PR TITLE
fix: APPS-2758   Author attribution missing on MEAP news article

### DIFF
--- a/gql/queries/ArticleNewsDetail.gql
+++ b/gql/queries/ArticleNewsDetail.gql
@@ -4,6 +4,7 @@
 query ArticleNewsDetail($slug: [String!]) {
     entry(section: "meapArticle", slug: $slug) {
         ... on meapArticle_meapArticle_Entry {
+            postDate
             id
             sectionHandle
             uri
@@ -14,6 +15,20 @@ query ArticleNewsDetail($slug: [String!]) {
             dateCreated
             category: articleCategories {
                 title
+                uri
+            }
+            contributors {
+                ... on contributors_staffMember_BlockType {
+                    byline
+                    staffMember {
+                        title
+                        to: slug
+                    }
+                }
+                ... on contributors_externalContributor_BlockType {
+                byline
+                title: contributor
+                }
             }
             heroImage {
                 ... on heroImage_heroImage_BlockType {

--- a/gql/queries/ArticleNewsDetail.gql
+++ b/gql/queries/ArticleNewsDetail.gql
@@ -14,7 +14,6 @@ query ArticleNewsDetail($slug: [String!]) {
             dateCreated
             category: articleCategories {
                 title
-                uri
             }
             contributors {
                 ... on contributors_staffMember_BlockType {

--- a/gql/queries/ArticleNewsDetail.gql
+++ b/gql/queries/ArticleNewsDetail.gql
@@ -4,7 +4,6 @@
 query ArticleNewsDetail($slug: [String!]) {
     entry(section: "meapArticle", slug: $slug) {
         ... on meapArticle_meapArticle_Entry {
-            postDate
             id
             sectionHandle
             uri

--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -8,6 +8,7 @@
             :title="page.title"
             parent-title="News"
         />
+
         <banner-text
             v-if="!page.heroImage || page.heroImage.length == 0"
             class="banner-text"
@@ -24,7 +25,7 @@
                 :title="page.title"
                 :text="page.text"
                 :category="parsedCategory"
-                :byline="page.byline"
+                :byline="parsedByline"
                 :locations="page.locations"
                 :date-created="page.dateCreated"
                 :align-right="true"
@@ -78,12 +79,33 @@ export default {
         parsedCategory() {
             return _get(this.page, "category[0].title", "")
         },
+        parsedByline() {
+            let byline = (this.page.contributors || []).map((contributor) => {
+                if (
+                    (contributor.staffMember &&
+                        contributor.staffMember.length > 0) ||
+                    contributor.title
+                )
+                    return `${contributor.byline || ""} ${contributor.title || contributor.staffMember[0].title
+                        }`
+            })
+            return byline.map((contributor) => {
+                return contributor
+            })
+        },
+        parsedDate() {
+            return format(new Date(this.page.postDate), "MMMM d, Y")
+        },
     },
 }
 </script>
 
-<style lang="scss" scoped>
+<style
+    lang="scss"
+    scoped
+>
 .page-news-detail {
+
     .banner-text,
     .banner-header {
         --color-theme: var(--color-visit-fushia-03);

--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -93,9 +93,6 @@ export default {
                 return contributor
             })
         },
-        parsedDate() {
-            return format(new Date(this.page.postDate), "MMMM d, Y")
-        },
     },
 }
 </script>

--- a/pages/about/news/_slug.vue
+++ b/pages/about/news/_slug.vue
@@ -15,7 +15,7 @@
             :category="parsedCategory"
             :title="page.title"
             :text="page.text"
-            :byline="page.byline"
+            :byline="parsedByline"
         />
 
         <section-wrapper class="section-banner">


### PR DESCRIPTION
Connected to [APPS-2758](https://uclalibrary.atlassian.net/browse/APPS-2758)

https://deploy-preview-119--test-meap.netlify.app/about/news/kids-play

<img width="954" alt="Screenshot 2024-06-04 at 12 20 39 PM" src="https://github.com/UCLALibrary/meap-website-nuxt/assets/751697/a31230ed-ac2f-414d-b16c-f9c033fa21f0">


[APPS-2758]: https://uclalibrary.atlassian.net/browse/APPS-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ