### PR TITLE
fix: params.path logic for general content page uri

### DIFF
--- a/pages/_.vue
+++ b/pages/_.vue
@@ -54,11 +54,14 @@ import stripMeapFromURI from "~/utils/stripMeapFromURI"
 export default {
     async asyncData({ $graphql, params }) {
         // Do not remove testing live preview
-
+        console.log("Testing live preview")
+        console.log("params", params)
         const data = await $graphql.default.request(GENERAL_CONTENT_DETAIL, {
-            slug: params.pathMatch.substring(
-                params.pathMatch.lastIndexOf("/") + 1
-            ),
+            slug: params.pathMatch
+                .replace(/\/$/, "")
+                .substring(
+                    params.pathMatch.replace(/\/$/, "").lastIndexOf("/") + 1
+                ),
         })
         return {
             page: _get(data, "entry", {}),


### PR DESCRIPTION
**Explanation:**

1. params.pathMatch.replace(/\/$/, ""):

- This removes the trailing / from params.pathMatch if it exists. The regular expression /\/$/ matches a / at the end of the string, and replace removes it.

2. lastIndexOf("/") and substring:

- After removing the trailing /, lastIndexOf("/") finds the last / in the modified string, and substring extracts the portion after it.

**Examples:**

- If params.pathMatch is /about/content/, the trailing / is removed, resulting in /about/content. The slug becomes content.
- If params.pathMatch is /about/content, the slug remains content.
- If params.pathMatch is /about/, the trailing / is removed, resulting in /about. The slug becomes about.
- If params.pathMatch is /about, the slug remains about.

This ensures the slug is correctly extracted in all cases.