### PR TITLE
feat: LADI-5184 MEAP Add title tag to all pages

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -25,6 +25,7 @@ useHead({
   ],
 })
 </script>
+
 <template>
   <div>
     <NuxtLoadingIndicator
@@ -32,12 +33,10 @@ useHead({
       height=3
     />
 
-
     <vue-skip-to
       to="#main"
       label="Skip to main content"
     />
-
 
     <NuxtLayout>
       <NuxtPage />

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,29 @@
 <script setup>
 // No Theme like Main Library Website
 const { enabled, state } = usePreviewMode()
+
+// set title
+useHead({
+  titleTemplate: (titleChunk) => {
+    // If undefined or blank then we don't need the pipe and space
+    return titleChunk === 'Homepage'
+      ? 'Modern Endangered Archives Program '
+      : `${titleChunk || 'Error'}  | Modern Endangered Archives Program `
+  },
+  htmlAttrs: {
+    lang: 'en',
+  },
+  meta: [
+    { charset: 'utf-8' },
+    {
+      name: 'viewport',
+      content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0',
+    },
+  ],
+  link: [
+    { rel: 'icon', type: 'image/svg', href: '/icon-ucla-favicon.svg' },
+  ],
+})
 </script>
 <template>
   <div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -30,6 +30,10 @@ console.log(data.value)
 
 const page = ref(_get(data.value, 'entries', {}))
 
+useHead({
+  title: 'Homepage'
+})
+
 watch(data, (newVal, oldVal) => {
   console.log('In watch preview enabled, newVal, oldVal', newVal, oldVal)
   page.value = _get(newVal, 'entry', {})


### PR DESCRIPTION
Connected to [LADI-5184](https://jira.library.ucla.edu/browse/LADI-5184)

Before
https://meap.library.ucla.edu/
After
https://deploy-preview-154--test-meap.netlify.app/

All pages are missing the title tag in the tab of the browser.

Modern Endangered Archives Program should be added as the title text

Other pages should also include | Modern Endangered Archives Program after the page specific title, e.g., About the Program | Modern Endangered Archives Program for [About the Program](https://meap.library.ucla.edu/about/)

BEFORE
<img width="385" height="274" alt="Screenshot 2026-05-19 at 2 27 07 PM" src="https://github.com/user-attachments/assets/54fe0ba9-d67f-4ddc-8042-16d6221d28d5" />

AFTER
<img width="528" height="421" alt="Screenshot 2026-05-19 at 3 18 09 PM" src="https://github.com/user-attachments/assets/ec46043d-4f45-4392-b1a9-986b4adc59d0" />

---

BEFORE
<img width="736" height="606" alt="Screenshot 2026-05-19 at 3 21 58 PM" src="https://github.com/user-attachments/assets/4b5c90bf-d03b-4ceb-8168-327413f2854d" />

AFTER
<img width="561" height="472" alt="Screenshot 2026-05-19 at 3 20 57 PM" src="https://github.com/user-attachments/assets/aca09b9e-6c87-4309-abe8-b6b0237c620c" />



[LADI-5184]: https://uclalibrary.atlassian.net/browse/LADI-5184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ