### PR TITLE
chore: LADI-5190b updated README's formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.
 
-
 ## Setup
 
 :exclamation: Verify that your development environment runs the Node and PNPM versions referenced in the project's [`actions.yml` file](https://github.com/UCLALibrary/meap-website-nuxt/blob/main/.github/workflows/setup-workspace/action.yml)
@@ -17,10 +16,9 @@ node -v
 pnpm -v
 ```
 
-
-- If your global Node or PNPM version is different, use the respective version setup steps:
-  - [Node version setup](#node-version-setup)
-  - [PNPM version setup](#pnpm-version-setup)
+If your global Node or PNPM version is different, use the respective version setup steps:
+- [Node version setup](#node-version-setup)
+- [PNPM version setup](#pnpm-version-setup)
 
 Install the project dependencies:
 
@@ -63,10 +61,11 @@ Check out the [Nuxt deployment documentation](https://nuxt.com/docs/getting-star
 ### Node Version Setup
 
 - Verify current version: `node -v`
-<br>
+
 - If the current node verison is different from the project node version, check for other existing versions: `nvm list` or `nvm ls`
-<br>
+
 - You should/may see an output such as this:
+
 ```bash
 -> v20.18.3
    v22.22.0
@@ -74,19 +73,15 @@ Check out the [Nuxt deployment documentation](https://nuxt.com/docs/getting-star
 default -> 20.18.3 (-> v20.18.3 *)
 ```
 
-- Install the project node version if it is not listed: `nvm install version-number`
-  - Example: `nvm install 20.20.2`
-<br>
-- Verify project version is installed: `nvm list`
-<br>
-- Switch to use project node version: `nvm use version-number`
-  - Example: `nvm use 20.20.2`
-<br>
+- Install the project node version if it is not listed: `nvm install version-number` (Example: `nvm install 20.20.2`)
+
+- Verify project version is installed: `nvm list` or `nvm ls`
+
+- Switch to use project node version: `nvm use version-number` (Example: `nvm use 20.20.2`)
+
 - Verify the project version: `node -v`
 
-:bulb: **To set specific node version as the global default:**
-
-`nvm alias default version-number`
+:bulb: **To set specific node version as the global default:** `nvm alias default version-number`
 
 ### PNPM Version Setup
 
@@ -101,15 +96,15 @@ If you are using a different global pnpm version (for example, v10+), you may se
 Node.js includes Corepack, which lets different projects use different pnpm versions.
 
 1. Enable Corepack: `corepack enable`
-<br>
-2. Set the correct pnpm version for the project: `corepack use pnpm@version-number`
-    - Example: `corepack use pnpm@9.12.1`
-<br>
+
+2. Set the correct pnpm version for the project: `corepack use pnpm@version-number` (Example: `corepack use pnpm@9.12.1`)
+
 3. Verify the version: `pnpm -v`
-<br>
+
 4. Run commands as usual:
 
     `pnpm install`
+
     `pnpm lint`
 
 #### Important notes


### PR DESCRIPTION
Connected to [LADI-5190](https://jira.library.ucla.edu/browse/LADI-5190)

**Page updated:** README.md

**Notes:**

- Fixed formatting that was broken in [previous PR](https://github.com/UCLALibrary/meap-website-nuxt/pull/156) 

<kbd>
<img width="600" height="200" alt="broken-readme-formatting" src="https://github.com/user-attachments/assets/18747298-1685-4fd6-8c9a-ad425b0c01a3" />
</kbd>
<br><br>

**Checklist:**

-   [x] I added github label for semantic versioning
-   ~~[ ] I double checked it looks like the designs~~
-   ~~[ ] I completed any required mobile breakpoint styling~~
-   ~~[ ] I completed any required hover state styling~~
-   ~~[ ] I included a working spec file~~
-   ~~[ ] I added notes above about how long it took to build this component~~
-   ~~[ ] UX has reviewed this PR~~
-   [x] I requested a PR review from the Dev team


[LADI-5190]: https://uclalibrary.atlassian.net/browse/LADI-5190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ